### PR TITLE
🚧 Start preimage oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "once_cell",
+ "rand",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -17,5 +17,8 @@ tokio = { version = "1.32.0", features = ["full"] }
 anyhow = "1.0.75"
 tracing = "0.1.37"
 
+[dev-dependencies]
+rand = "0.8.5"
+
 [features]
 tracing = []

--- a/crates/preimage/src/lib.rs
+++ b/crates/preimage/src/lib.rs
@@ -8,6 +8,4 @@ mod traits;
 pub use traits::{Hint, Hinter, Key, Oracle};
 
 mod types;
-pub use types::{
-    HinterFn, Keccak256Key, KeyType, LocalIndexKey, OracleFn, PreimageGetter, ReadWriterPair,
-};
+pub use types::{Keccak256Key, KeyType, LocalIndexKey, PreimageGetter};

--- a/crates/preimage/src/types.rs
+++ b/crates/preimage/src/types.rs
@@ -1,9 +1,17 @@
 //! This module contains the types for the preimage-oracle crate.
 
-use crate::{traits::Hint, Key};
+use crate::Key;
 use alloy_primitives::B256;
 use anyhow::Result;
-use std::io::{BufReader, BufWriter, Read, Write};
+
+/// A [PreimageGetter] is a function that can be used to fetch pre-images.
+pub type PreimageGetter = Box<dyn Fn(B256) -> Result<Vec<u8>>>;
+
+/// A [Keccak256Key] wraps a keccak256 hash to use it as a typed pre-image key.
+pub type Keccak256Key = B256;
+
+/// A [LocalIndexKey] is a key local to the program, indexing a special program input.
+pub type LocalIndexKey = u64;
 
 #[repr(u8)]
 pub enum KeyType {
@@ -15,9 +23,6 @@ pub enum KeyType {
     GlobalKeccak = 2,
 }
 
-/// A [LocalIndexKey] is a key local to the program, indexing a special program input.
-pub type LocalIndexKey = u64;
-
 impl Key for LocalIndexKey {
     fn preimage_key(self) -> B256 {
         let mut out = B256::ZERO;
@@ -27,60 +32,9 @@ impl Key for LocalIndexKey {
     }
 }
 
-/// A [Keccak256Key] wraps a keccak256 hash to use it as a typed pre-image key.
-pub type Keccak256Key = B256;
-
 impl Key for Keccak256Key {
     fn preimage_key(mut self) -> B256 {
         self[0] = KeyType::GlobalKeccak as u8;
         self
     }
 }
-
-/// An [OracleFn] is a function that can be used to fetch pre-images.
-pub type OracleFn = fn(key: dyn Key) -> Vec<u8>;
-
-/// A [HinterFn] is a function that can be used to write a hint to the host.
-pub type HinterFn = fn(hint: dyn Hint);
-
-/// A [ReadWriterPair] is a wrapper around two types, implementing [Read] and [Write].
-pub struct ReadWriterPair<R: Read, W: ?Sized + Write> {
-    reader: BufReader<R>,
-    writer: BufWriter<W>,
-}
-
-impl<R: Read, W: Write> ReadWriterPair<R, W> {
-    pub fn new(reader: R, writer: W) -> Self {
-        Self {
-            reader: BufReader::new(reader),
-            writer: BufWriter::new(writer),
-        }
-    }
-}
-
-impl<R, W> Read for ReadWriterPair<R, W>
-where
-    R: Read,
-    W: Write,
-{
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.reader.read(buf)
-    }
-}
-
-impl<R, W> Write for ReadWriterPair<R, W>
-where
-    R: Read,
-    W: Write,
-{
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.writer.write(buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.writer.flush()
-    }
-}
-
-/// A [PreimageGetter] is a function that can be used to fetch pre-images.
-pub type PreimageGetter = Box<dyn Fn(B256) -> Result<Vec<u8>>>;


### PR DESCRIPTION
## Overview

Does away with the idea of a shared buffer and uses an mpsc channel to communicate between the preimage server and client.