### PR TITLE
🛠️ Enable `oracle` open mips tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "criterion",
  "fnv",
  "once_cell",
+ "preimage-oracle",
  "rand",
  "revm",
  "serde",

--- a/crates/mipsevm/Cargo.toml
+++ b/crates/mipsevm/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.75"
 tracing = "0.1.37"
 
 [dev-dependencies]
+preimage-oracle = { path = "../preimage" }
 rand = "0.8.5"
 revm = "3.3.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }


### PR DESCRIPTION
## Overview

Enables the `oracle` open MIPS tests and fixes the i/o in the `PreimageWrite` syscall handler in the MIPS VM.