### PR TITLE
⚡ perf: Optimize `Page` intermediate hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ credits for the original idea and reference implementation of this concept go to
 ### `cannon-mipsevm` benchmarks
 
 The below benchmark was ran on a 2021 Macbook Pro with an M1 Max and 32 GB of unified memory
-on commit [`83e4c56`](https://github.com/anton-rs/cannon-rs/tree/83e4c5643193aac19046ef29b5018137b5eb05f2).
+on commit [`71b68d5`](https://github.com/anton-rs/cannon-rs/pull/17/commits/71b68d52fb858cfc544c1430b482aeaef460552e).
 
 | Benchmark Name             | `cannon` mean (Reference) | `cannon-rs` mean    |
 |----------------------------|---------------------------|---------------------|
-| Memory Merkle Root (25MB)  | 736.94 ms                 | 328.67 µs (-99%)    |
-| Memory Merkle Root (50MB)  | 1.54s                     | 548.85 ms (-63.36%) |
-| Memory Merkle Root (100MB) | 3.34s                     | 1.16s (-65.29%)     |
-| Memory Merkle Root (200MB) | 6.30s                     | 2.14s (-66.01%)     |
+| Memory Merkle Root (25MB)  | 736.94 ms                 | 29.58 µs (-99%)     |
+| Memory Merkle Root (50MB)  | 1.54s                     | 7.25 ms (-99%)      |
+| Memory Merkle Root (100MB) | 3.34s                     | 273.76 ms (-91.8%)  |
+| Memory Merkle Root (200MB) | 6.30s                     | 1.65s (-73.81%)     |
 
 *todo - execution benchmarks*
 

--- a/crates/mipsevm/benches/memory.rs
+++ b/crates/mipsevm/benches/memory.rs
@@ -3,7 +3,10 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::RngCore;
 
 fn merkle_root(c: &mut Criterion) {
-    c.bench_function("Merkle Root (memory size = 25 MB)", |b| {
+    let mut g = c.benchmark_group("memory");
+    g.sample_size(10);
+
+    g.bench_function("Merkle Root (memory size = 25 MB)", |b| {
         let mut memory = Memory::default();
         let mut data = vec![0u8; 25_000_000];
         rand::thread_rng().fill_bytes(&mut data[..]);
@@ -15,7 +18,7 @@ fn merkle_root(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("Merkle Root (memory size = 50 MB)", |b| {
+    g.bench_function("Merkle Root (memory size = 50 MB)", |b| {
         let mut memory = Memory::default();
         let mut data = vec![0u8; 50_000_000];
         rand::thread_rng().fill_bytes(&mut data[..]);
@@ -27,7 +30,7 @@ fn merkle_root(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("Merkle Root (memory size = 100 MB)", |b| {
+    g.bench_function("Merkle Root (memory size = 100 MB)", |b| {
         let mut memory = Memory::default();
         let mut data = vec![0u8; 100_000_000];
         rand::thread_rng().fill_bytes(&mut data[..]);
@@ -39,7 +42,7 @@ fn merkle_root(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("Merkle Root (memory size = 200 MB)", |b| {
+    g.bench_function("Merkle Root (memory size = 200 MB)", |b| {
         let mut memory = Memory::default();
         let mut data = vec![0u8; 200_000_000];
         rand::thread_rng().fill_bytes(&mut data[..]);

--- a/crates/mipsevm/src/utils.rs
+++ b/crates/mipsevm/src/utils.rs
@@ -3,6 +3,7 @@
 use alloy_primitives::{keccak256, B256};
 
 /// Concatenate two fixed sized arrays together into a new array with minimal reallocation.
+#[inline(always)]
 pub(crate) fn concat_fixed<T, const N: usize, const M: usize>(a: [T; N], b: [T; M]) -> [T; N + M]
 where
     T: Copy + Default,
@@ -15,6 +16,7 @@ where
 }
 
 /// Hash the concatenation of two fixed sized arrays.
+#[inline(always)]
 pub(crate) fn keccak_concat_fixed<T, const N: usize, const M: usize>(a: [T; N], b: [T; M]) -> B256
 where
     T: Copy + Default,


### PR DESCRIPTION
## Overview

Optimizes `Page` intermediate hashing by not requiring all invalidated pages to be merkleized when computing a subtree merkle root.