### PR TITLE
♻️ Move to `[u8; 32]` over Alloy's B256 wrapper

### DIFF
--- a/crates/mipsevm/src/mips/instrumented.rs
+++ b/crates/mipsevm/src/mips/instrumented.rs
@@ -280,7 +280,7 @@ mod test {
             if ins.state.exited {
                 break;
             }
-            ins.step(false).unwrap();
+            ins.step(true).unwrap();
         }
 
         assert!(ins.state.exited, "must exit");

--- a/crates/mipsevm/src/mips/instrumented.rs
+++ b/crates/mipsevm/src/mips/instrumented.rs
@@ -1,7 +1,6 @@
 //! This module contains the [InstrumentedState] definition.
 
 use crate::{traits::PreimageOracle, Address, State, StepWitness};
-use alloy_primitives::B256;
 use anyhow::Result;
 use std::io::{BufWriter, Write};
 
@@ -32,7 +31,7 @@ pub struct InstrumentedState<O: Write, E: Write, P: PreimageOracle> {
     /// Cached pre-image data, including 8 byte length prefix
     pub(crate) last_preimage: Vec<u8>,
     /// Key for the above preimage
-    pub(crate) last_preimage_key: B256,
+    pub(crate) last_preimage_key: [u8; 32],
     /// The offset we last read from, or max u32 if nothing is read at
     /// the current step.
     pub(crate) last_preimage_offset: u32,
@@ -51,10 +50,10 @@ where
             std_err: BufWriter::new(std_err),
             last_mem_access: 0,
             mem_proof_enabled: false,
-            mem_proof: [0; 28 * 32],
+            mem_proof: [0u8; 28 * 32],
             preimage_oracle: oracle,
             last_preimage: Vec::default(),
-            last_preimage_key: B256::default(),
+            last_preimage_key: [0u8; 32],
             last_preimage_offset: 0,
         }
     }
@@ -79,7 +78,7 @@ where
             witness = Some(StepWitness {
                 state: self.state.encode_witness()?,
                 mem_proof: instruction_proof.to_vec(),
-                preimage_key: B256::ZERO,
+                preimage_key: [0u8; 32],
                 preimage_value: Vec::default(),
                 preimage_offset: 0,
             })

--- a/crates/mipsevm/src/mips/mips_vm.rs
+++ b/crates/mipsevm/src/mips/mips_vm.rs
@@ -7,7 +7,6 @@ use crate::{
     types::Syscall,
     Address, Fd, InstrumentedState, PreimageOracle,
 };
-use alloy_primitives::B256;
 use anyhow::Result;
 use std::{
     io::{self, Cursor, Read, Write},
@@ -29,7 +28,11 @@ where
     /// ### Returns
     /// - `Ok((data, data_len))`: The preimage data and length.
     /// - `Err(_)`: An error occurred while fetching the preimage.
-    pub(crate) fn read_preimage(&mut self, key: B256, offset: u32) -> Result<(B256, usize)> {
+    pub(crate) fn read_preimage(
+        &mut self,
+        key: [u8; 32],
+        offset: u32,
+    ) -> Result<([u8; 32], usize)> {
         if key != self.last_preimage_key {
             let data = self.preimage_oracle.get(key)?;
             self.last_preimage_key = key;
@@ -45,7 +48,7 @@ where
 
         // TODO(clabby): This could be problematic if the `Cursor`'s read function returns
         // 0 as EOF rather than the amount of bytes read into `data`.
-        let mut data = B256::ZERO;
+        let mut data = [0u8; 32];
         let data_len =
             Cursor::new(&self.last_preimage[offset as usize..]).read(data.as_mut_slice())?;
         Ok((data, data_len))

--- a/crates/mipsevm/src/state.rs
+++ b/crates/mipsevm/src/state.rs
@@ -3,7 +3,6 @@
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{witness::STATE_WITNESS_SIZE, Memory, StateWitness, VMStatus};
-use alloy_primitives::B256;
 use anyhow::Result;
 
 /// The [State] struct contains the internal model of the MIPS emulator state.
@@ -15,7 +14,7 @@ pub struct State {
     /// The [Memory] of the emulated MIPS thread context.
     pub memory: Rc<RefCell<Memory>>,
     /// The preimage key for the given state.
-    pub preimage_key: B256,
+    pub preimage_key: [u8; 32],
     /// The preimage offset.
     pub preimage_offset: u32,
     /// The current program counter.

--- a/crates/mipsevm/src/test_utils/evm.rs
+++ b/crates/mipsevm/src/test_utils/evm.rs
@@ -116,7 +116,7 @@ impl MipsEVM<CacheDB<EmptyDB>> {
             crate::debug!(
                 target: "mipsevm::evm",
                 "Reading preimage key {:x} at offset {}",
-                witness.preimage_key,
+                B256::from(witness.preimage_key),
                 witness.preimage_offset
             );
 
@@ -165,7 +165,7 @@ impl MipsEVM<CacheDB<EmptyDB>> {
                 anyhow::bail!(
                     "Post-state hash does not match state hash in log: {:x} != {:x}",
                     output,
-                    post_state.state_hash()
+                    B256::from(post_state.state_hash())
                 );
             }
 
@@ -447,7 +447,7 @@ mod test {
             let step_witness = StepWitness {
                 state: initial_state.encode_witness().unwrap(),
                 mem_proof: instruction_proof.to_vec(),
-                preimage_key: alloy_primitives::B256::ZERO,
+                preimage_key: [0u8; 32],
                 preimage_value: Vec::default(),
                 preimage_offset: 0,
             };

--- a/crates/mipsevm/src/traits.rs
+++ b/crates/mipsevm/src/traits.rs
@@ -1,13 +1,12 @@
 //! This module contains the various traits used in this crate.
 
-use alloy_primitives::B256;
 use anyhow::Result;
 
 /// A [StateWitnessHasher] is a trait describing the functionality of a type
 /// that computes a witness hash.
 pub trait StateWitnessHasher {
     /// Compute the [crate::StateWitness] hash.
-    fn state_hash(&self) -> B256;
+    fn state_hash(&self) -> [u8; 32];
 }
 
 /// A [PreimageOracle] is a trait describing the functionality of a preimage
@@ -28,5 +27,5 @@ pub trait PreimageOracle {
     /// - `Ok(Some(preimage))`: The preimage for the given key.
     /// - `Ok(None)`: The preimage for the given key does not exist.
     /// - `Err(_)`: An error occurred while fetching the preimage.
-    fn get(&self, key: B256) -> Result<&[u8]>;
+    fn get(&self, key: [u8; 32]) -> Result<&[u8]>;
 }

--- a/crates/preimage/src/traits.rs
+++ b/crates/preimage/src/traits.rs
@@ -1,13 +1,12 @@
 //! This module contains the traits for the preimage-oracle crate.
 
-use alloy_primitives::B256;
 use anyhow::Result;
 
 /// The [Key] trait describes the behavior of a pre-image key that may be wrapped
 /// into a 32-byte type-prefixed key.
 pub trait Key {
     /// Changes the [Key] commitment into a 32-byte type-prefixed preimage key.
-    fn preimage_key(self) -> B256;
+    fn preimage_key(self) -> [u8; 32];
 }
 
 /// The [Oracle] trait describes the behavior of a read-only pre-image oracle.

--- a/crates/preimage/src/types.rs
+++ b/crates/preimage/src/types.rs
@@ -1,17 +1,16 @@
 //! This module contains the types for the preimage-oracle crate.
 
 use crate::Key;
-use alloy_primitives::B256;
 use anyhow::Result;
 
 /// A [PreimageGetter] is a function that can be used to fetch pre-images.
-pub type PreimageGetter = Box<dyn Fn(B256) -> Result<Vec<u8>>>;
+pub type PreimageGetter = Box<dyn Fn([u8; 32]) -> Result<Vec<u8>>>;
 
 /// A [HintHandler] is a function that can be used to handle hints from a [crate::HintWriter].
 pub type HintHandler = Box<dyn Fn(&[u8]) -> Result<()>>;
 
 /// A [Keccak256Key] wraps a keccak256 hash to use it as a typed pre-image key.
-pub type Keccak256Key = B256;
+pub type Keccak256Key = [u8; 32];
 
 /// A [LocalIndexKey] is a key local to the program, indexing a special program input.
 pub type LocalIndexKey = u64;
@@ -37,8 +36,8 @@ impl From<u8> for KeyType {
 }
 
 impl Key for LocalIndexKey {
-    fn preimage_key(self) -> B256 {
-        let mut out = B256::ZERO;
+    fn preimage_key(self) -> [u8; 32] {
+        let mut out = [0u8; 32];
         out[0] = KeyType::Local as u8;
         out[24..].copy_from_slice(&self.to_be_bytes());
         out
@@ -46,7 +45,7 @@ impl Key for LocalIndexKey {
 }
 
 impl Key for Keccak256Key {
-    fn preimage_key(mut self) -> B256 {
+    fn preimage_key(mut self) -> [u8; 32] {
         self[0] = KeyType::GlobalKeccak as u8;
         self
     }


### PR DESCRIPTION
## Overview

Moves us to using `[u8; 32]` over Alloy's `B256` wrapper in most performance-critical places.