### PR TITLE
POC: Parallelize merkleization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,9 +408,11 @@ dependencies = [
  "once_cell",
  "preimage-oracle",
  "rand",
+ "rayon",
  "revm",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/mipsevm/Cargo.toml
+++ b/crates/mipsevm/Cargo.toml
@@ -16,6 +16,8 @@ serde_json = "1.0.106"
 fnv = "1.0.7"
 elf = "0.7.2"
 revm = { version = "3.3.0", features = ["no_gas_measuring"] }
+tokio = "1.32.0"
+rayon = "1.8.0"
 
 # misc
 anyhow = "1.0.75"


### PR DESCRIPTION
## Overview

Bad idea, just a loose test. There could be something to making the merkle root hashing asynchronous (i.e. lazy calculation, not parallelizing sub-trees like here), but the overhead in this method is definitely not it.