### PR TITLE
readme: add dependencies note

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ To get started, a few dependencies are required:
 * [Rust toolchain][rustup]
     * Recommended: [`cargo-nextest`][nextest]
 * [Go toolchain][golang]
-* [binutils][binutils]
+* [binutils][binutils] 
+    * **Note for macOS users:** Please avoid installing `binutils` using `brew`.
 
 ### Testing
 


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/242906-t-compiler.2Farm/topic/aarch64-apple-darwin.20CI.2FCD.20and.20tier.201.3F/near/444848672

I use macOS and install `binutils` through `brew`, but the entire build fails because of issues related to the link above. It took me a while to figure out the solution.